### PR TITLE
feat: adding in cpulimit and setting fim to .80 available cpu max

### DIFF
--- a/archived/gcp-cos-basic-fim/Dockerfile
+++ b/archived/gcp-cos-basic-fim/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.8
 
 # python3 shared with most images
 RUN apk add --no-cache \
-    python3 py3-pip \
+    python3 py3-pip cpulimit \
   && pip3 install --upgrade pip
 # Image specific layers under this line
 RUN apk add --no-cache fcron rsyslog bash findutils tzdata

--- a/archived/gcp-cos-basic-fim/start.py
+++ b/archived/gcp-cos-basic-fim/start.py
@@ -11,12 +11,12 @@ os.system("echo FIM_IGNORE_FILE=$FIM_IGNORE_FILE >> /root.crontab")
 os.system("echo FIM_IGNORE_PATH=$FIM_IGNORE_PATH >> /root.crontab")
 os.system("echo FIM_IGNORE_REGEX=$FIM_IGNORE_REGEX >> /root.crontab")
 # Run a filesystem scan every day unless one is in progress.
-os.system("echo \"$(($RANDOM % 60))   $(($RANDOM % 24))   *   *   *   /fim/scan.sh 2>&1  >> /logs/fimcron.log \" >> /root.crontab")
+os.system("echo \"$(($RANDOM % 60))   $(($RANDOM % 24))   *   *   *   cpulimit -l 80 -i /fim/scan.sh 2>&1  >> /logs/fimcron.log \" >> /root.crontab")
 os.system("fcrontab -u root /root.crontab")
 os.system("rm /root.crontab")
 
 # Perform a bootup Scan
-os.system("/fim/scan.sh &")
+os.system("cpulimit -l 80 -i /fim/scan.sh &")
 
 # Run cron
 os.system("/usr/sbin/fcron -f -d")


### PR DESCRIPTION
Setting cpulimit on FIM so that it has to be below .80 CPU use.

Available CPU use with cpulimit is #cores * 100% 

So, if our nodes have 4 CPU's, we have a max of 400% CPU use. I went with 80%, or .8. Since the CPU limit for these pods is 1.0, that leaves about .20 overhead for whatever else the pod needs to run.

## Testing:
It was working on DEV for :ops-1512v1 but then someone did a deploy and it reverted to :latest :woman_facepalming: 

This is what firing the raw command `cpulimit -l 80 -i /fim/scan.sh` looks like in a container. First run is without cpulimit, 2nd is with.

![image](https://github.com/user-attachments/assets/c6d294d7-a05d-4eda-869b-b228a47e12c5)

